### PR TITLE
Fix issue with joining empty strings

### DIFF
--- a/telegrafFritzBox.py
+++ b/telegrafFritzBox.py
@@ -52,7 +52,7 @@ def extractvar(answer, variable, integer=False, string=True, name=""):
     return avar
 
 def assemblevar(*args):
-    data = ','.join(list(args))+','
+    data = ','.join([x for x in list(args) if x!=''])+','
     #cleaning up output
     data = data.replace("New", "")
     data = data.replace(",,",",")


### PR DESCRIPTION
If arg contains an empty string it will output invalid influx syntax (e.g. leading comma for data)