### PR TITLE
fixed empty data field joining leads to invalid influx line

### DIFF
--- a/telegrafFritzBox.py
+++ b/telegrafFritzBox.py
@@ -52,19 +52,13 @@ def extractvar(answer, variable, integer=False, string=True, name=""):
     return avar
 
 def assemblevar(*args):
-    data = ','.join(list(args))+','
+    data = ','.join([a for a in args if a != ''])
     #cleaning up output
     data = data.replace("New", "")
-    data = data.replace(",,",",")
-    data = data.replace(",,",",")
-    data = data.replace(",,",",")
-    data = data.replace(",,",",")
-    data = data[:-1]
     return data
 
 def influxrow(tag, data):
-    influx = FRITZBOX_ID +','+ fbName +  ',source=' + tag + ' ' + data
-    print(influx)
+    print(f'{FRITZBOX_ID},{fbName},source={tag} {data}')
 
 # Speccialist Stats that have to be assembled (counted) ourselfes
 def gethosts():


### PR DESCRIPTION
Sometimes (was not able to deterministic reproduce the error) the Fritzbox does not deliver the Modelname. This leads to a leading comma within `assemblevar` and then produces an invalid influx line. I fixed this (and every other occasion when an empty data field is part of data) by filtering the args to non empty ones, joining and then doing your `New` replacement. 